### PR TITLE
Add check if bridge is up

### DIFF
--- a/templates/up.sh.j2
+++ b/templates/up.sh.j2
@@ -1,6 +1,11 @@
 #!/bin/sh
 # {{ ansible_managed }}
-brctl addbr {{ openvpn_bridge_dev }}; true
+set +e
+brctl addbr {{ openvpn_bridge_dev }}
+if [ $? != 0 ]; then
+	sleep 2
+	exec systemctl restart openvpn.service
+fi
 brctl addif {{ openvpn_bridge_dev }} {{ openvpn_dev }}; true
 brctl addif {{ openvpn_bridge_dev }} {{ openvpn_interface }}; true
 ip link set {{ openvpn_bridge_dev }} up;


### PR DESCRIPTION
For some reason the bridge module is not loaded correctly on boot so the
service needs a restart every time after a reboot to prevent this a
check is added that does that automatticaly