### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This role requires an apt based system.
 | openvpn_use_bridge                 | `false`                                          | Use a bridge device with `tap` interface instead of the default `tun`.                                                                                          |
 | openvpn_devtype                    |                                                  | Specify the device type (`tun`/`tap`) to be used. If not set, it will be a tun device unless `openvpn_use_bridge` is set.                                       |
 | openvpn_dev                        | `tap0`                                           | The name of the generated device if `openvpn_devtype` is set.                                                                                                   |
+| openvpn_fetch_configs              | `true`                                           | Download client configurations from the server.                                                                                                                 |
 
 ### Client object
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,3 +44,4 @@ openvpn_cipher: AES-256-CBC
 openvpn_use_lzo: true
 openvpn_default_client_push: []
 openvpn_client_cert_only_auth: false
+openvpn_fetch_configs: true

--- a/tasks/client_keys.yml
+++ b/tasks/client_keys.yml
@@ -80,7 +80,7 @@
     src: "{{ openvpn_base_dir }}/{{ item.name }}-{{ inventory_hostname }}.ovpn"
     dest: "/tmp/ansible/{{ item.name }}/{{ inventory_hostname }}.ovpn"
     flat: yes
-  when: openvpn_clients is defined
+  when: openvpn_fetch_configs and openvpn_clients is defined
   with_items: "{{ openvpn_clients }}"
 
 - name: Fetch public client config without certs
@@ -88,4 +88,4 @@
     src: "{{  openvpn_base_dir  }}/generell-{{ inventory_hostname }}.ovpn"
     dest: "/tmp/{{ inventory_hostname }}.ovpn"
     flat: yes
-  when: openvpn_ldap is defined
+  when: openvpn_fetch_configs and openvpn_ldap is defined

--- a/tasks/client_keys.yml
+++ b/tasks/client_keys.yml
@@ -63,6 +63,8 @@
   with_together:
     - "{{ client_certs.results }}"
     - "{{ client_keys.results }}"
+  loop_control:
+    label: "{{ item.0.item }}"
 
 - name: Generate client config for ldap auth
   template:

--- a/tasks/server_keys.yml
+++ b/tasks/server_keys.yml
@@ -117,9 +117,10 @@
     mode: 744
 
 - name: Ensure certificate revocation list database exists
-  file:
-    path: "{{openvpn_key_dir}}/index.txt"
-    state: touch
+  copy:
+    dest: "{{openvpn_key_dir}}/index.txt"
+    content: ""
+    force: no
 
 - name: Set up certificate revocation list
   command: sh revoke.sh


### PR DESCRIPTION
This is a combination of various changes, all so small that I thought one PR would suffice.

What are the commits doing?

1.  Simplifies the output of the current item to just the item object containing the name of the client and therefor excludes client keys etc from the ansible output. This is also a good idea if you are using tower or so to log your ansible runs since the keys are sensitive data.

1. The file module always reported the crl index as changed, which makes sense since touch actually Changes the file. But in the end this is not what the task tries to achieve, it merely tries to create the file. Therefore I updated the usage from `file` to `copy` which will only show the changed message when it actually creates the file.

1. Added an option to disable fetching of client configs. It is still on by default, but endusers can now disable it and pass `-e 'openvpn_fetch_configs: yes' to the invocation of the playbook if the need to fetch the certs.