### PR TITLE
replaced inventory_hostname with openvpn_server_hostname

### DIFF
--- a/tasks/client_config_dir.yml
+++ b/tasks/client_config_dir.yml
@@ -1,5 +1,5 @@
 - name: Write client configs to client-config-dir
   template:
     src: staticclient.j2
-    dest: "{{ openvpn_base_dir }}/staticclients/OpenVPN-Client-{{  inventory_hostname[:24]  }}-{{  item.name[:24]  }}"
+    dest: "{{ openvpn_base_dir }}/staticclients/OpenVPN-Client-{{ openvpn_server_hostname[:24] }}-{{ item.name[:24] }}"
   when: item.ip_address is defined

--- a/tasks/client_keys.yml
+++ b/tasks/client_keys.yml
@@ -9,7 +9,7 @@
     mode: 0400
 
 - name: Generate client key
-  command: "openssl req -nodes -newkey rsa:{{ openvpn_rsa_bits }} -keyout {{ item.name }}.key -out {{ item.name }}.csr -days {{ openvpn_openssl_days }} -{{ openvpn_openssl_digest }} -subj /CN=OpenVPN-Client-{{  inventory_hostname[:24]  }}-{{  item.name[:24]  }}/"
+  command: "openssl req -nodes -newkey rsa:{{ openvpn_rsa_bits }} -keyout {{ item.name }}.key -out {{ item.name }}.csr -days {{ openvpn_openssl_days }} -{{ openvpn_openssl_digest }} -subj /CN=OpenVPN-Client-{{ openvpn_server_hostname[:24] }}-{{  item.name[:24]  }}/"
   args:
     chdir: "{{ openvpn_key_dir }}"
     creates: "{{ item.name }}.key"
@@ -55,7 +55,7 @@
 - name: Generate client config
   template:
     src: client.ovpn.j2
-    dest: "{{ openvpn_base_dir }}/{{ item.0.item.name }}-{{ inventory_hostname }}.ovpn"
+    dest: "{{ openvpn_base_dir }}/{{ item.0.item.name }}-{{ openvpn_server_hostname }}.ovpn"
     owner: root
     group: root
     mode: 0400
@@ -69,7 +69,7 @@
 - name: Generate client config for ldap auth
   template:
     src: client.ovpn.j2
-    dest: "{{  openvpn_base_dir  }}/generell-{{ inventory_hostname }}.ovpn"
+    dest: "{{  openvpn_base_dir  }}/generell-{{ openvpn_server_hostname }}.ovpn"
     owner: root
     group: root
     mode: 0400
@@ -77,15 +77,15 @@
 
 - name: Fetch client config
   fetch:
-    src: "{{ openvpn_base_dir }}/{{ item.name }}-{{ inventory_hostname }}.ovpn"
-    dest: "/tmp/ansible/{{ item.name }}/{{ inventory_hostname }}.ovpn"
+    src: "{{ openvpn_base_dir }}/{{ item.name }}-{{ openvpn_server_hostname }}.ovpn"
+    dest: "/tmp/ansible/{{ item.name }}/{{ openvpn_server_hostname }}.ovpn"
     flat: yes
   when: openvpn_fetch_configs and openvpn_clients is defined
   with_items: "{{ openvpn_clients }}"
 
 - name: Fetch public client config without certs
   fetch:
-    src: "{{  openvpn_base_dir  }}/generell-{{ inventory_hostname }}.ovpn"
-    dest: "/tmp/{{ inventory_hostname }}.ovpn"
+    src: "{{  openvpn_base_dir  }}/generell-{{ openvpn_server_hostname }}.ovpn"
+    dest: "/tmp/{{ openvpn_server_hostname }}.ovpn"
     flat: yes
   when: openvpn_fetch_configs and openvpn_ldap is defined

--- a/tasks/server_keys.yml
+++ b/tasks/server_keys.yml
@@ -29,7 +29,7 @@
   when: openvpn_ca_key is defined
 
 - name: Generate CA key
-  command: openssl req -nodes -newkey rsa:{{openvpn_rsa_bits}} -keyout ca-key.pem -out ca-csr.pem -days {{ openvpn_openssl_days }} -{{ openvpn_openssl_digest }} -subj /CN=OpenVPN-CA-{{inventory_hostname[:53]}}/
+  command: openssl req -nodes -newkey rsa:{{openvpn_rsa_bits}} -keyout ca-key.pem -out ca-csr.pem -days {{ openvpn_openssl_days }} -{{ openvpn_openssl_digest }} -subj /CN=OpenVPN-CA-{{ openvpn_server_hostname[:53] }}/
   args:
     chdir: "{{openvpn_key_dir}}"
     creates: ca-key.pem
@@ -49,7 +49,7 @@
   when: openvpn_ca_key is not defined
 
 - name: Generate server key
-  command: openssl req -nodes -newkey rsa:{{openvpn_rsa_bits}} -keyout server.key -out server.csr -days {{ openvpn_openssl_days }} -{{ openvpn_openssl_digest }} -subj /CN=OpenVPN-Server-{{inventory_hostname[:49]}}/
+  command: openssl req -nodes -newkey rsa:{{openvpn_rsa_bits}} -keyout server.key -out server.csr -days {{ openvpn_openssl_days }} -{{ openvpn_openssl_digest }} -subj /CN=OpenVPN-Server-{{ openvpn_server_hostname[:49] }}/
   args:
     chdir: "{{openvpn_key_dir}}"
     creates: server.key

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -59,5 +59,5 @@ key-direction 1
 
 
 {% if openvpn_verify_cn|bool %}
-verify-x509-name OpenVPN-Server-{{inventory_hostname[:49]}} name
+verify-x509-name OpenVPN-Server-{{ openvpn_server_hostname[:49] }} name
 {% endif %}

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -89,7 +89,7 @@ log-append /var/log/openvpn.log
 verb 3
 
 {% if openvpn_verify_cn|bool %}
-verify-x509-name OpenVPN-Client-{{inventory_hostname[:24]}} name-prefix
+verify-x509-name OpenVPN-Client-{{ openvpn_server_hostname[:24] }} name-prefix
 remote-cert-tls client
 {% endif %}
 


### PR DESCRIPTION
This commit replaces all mentions of `inventory_hostname` with `openvpn_server_hostname`. This hides the inventory hostname from clients if verify_cn is used and is more consistent with the expected usage of `openvpn_server_hostname`

This change is backwards incompatible if `openvpn_server_hostname` doesn't match `inventory_hostname` (it defaults to the latter).