### PR TITLE
Mute replay warnings

### DIFF
--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -104,10 +104,13 @@ remote-cert-tls client
 
 {% if openvpn_enable_management|bool %}
 management {{openvpn_management_bind}}
-{% if openvpn_management_client_user %}
+    {%- if openvpn_management_client_user %}
+
 management-client-user {{openvpn_management_client_user}}
+    {%- endif %}
+
 {% endif %}
-{% endif %}
+mute-replay-warnings
 
 {% if openvpn_use_ldap|bool %}
 ### LDAP AUTH ###


### PR DESCRIPTION
They show up in the log as an error but really are just warnings
which can in most cases be ignored