### PR TITLE
server.conf.j2: Fix bridging without ifconfig-push

### DIFF
--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -64,7 +64,9 @@ tls-cipher {{ openvpn_tls_cipher|join(':') }}
 
 # Miscellaneous:
 
+{% if not openvpn_use_bridge or openvpn_bridge_enable_dhcp %}
 ifconfig-pool-persist ipp.txt
+{% endif %}
 keepalive 5 30
 persist-key
 persist-tun


### PR DESCRIPTION
Previously, using `openvpn_use_bridge: True` together with
`openvpn_bridge_enable_dhcp: False` led to an error because
with this specific configuration, there's no `ifconfig-pool`
and therefore the option `ifconfig-pool-persist` is invalid.